### PR TITLE
Fixed typographical error, changed auxilliary to auxiliary in README.

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -63,7 +63,7 @@ attractive than computing the 'intended' work.
 Run `timelock produce --rounds <number_of_rounds>` to produce a chainfile with
 a single entry, representing <number_of_rounds> rounds of SHA512. I've not
 implemented parallelism yet, and probably will never in the core tool; instead
-an auxilliary tool will launch multiple production processes.
+an auxiliary tool will launch multiple production processes.
 
 
 ## chainfile concatenation


### PR DESCRIPTION
dorianj, I've corrected a typographical error in the documentation of the [timelock](https://github.com/dorianj/timelock) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
